### PR TITLE
Job to compute state hash

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,4 @@ web: bundle exec puma -C config/puma.rb
 release: rake db:migrate
 get_ethscriptions: bundle exec clockwork config/clock.rb
 process_ethscriptions: bundle exec clockwork config/processor_clock.rb
+state_attestations: bundle exec clockwork config/state_attestation_clock.rb

--- a/app/models/contract.rb
+++ b/app/models/contract.rb
@@ -9,6 +9,14 @@ class Contract < ApplicationRecord
   has_many :contract_calls, foreign_key: :effective_contract_address, primary_key: :address
   has_one :transaction_receipt, through: :contract_transaction
 
+  scope :oldest_first, -> {
+    order(block_number: :asc, transaction_index: :asc, internal_transaction_index: :asc)
+  }
+  
+  scope :newest_first, -> {
+    order(block_number: :desc, transaction_index: :desc, internal_transaction_index: :desc)
+  }
+
   attr_reader :implementation
   
   delegate :implements?, to: :implementation

--- a/app/models/contract_artifact.rb
+++ b/app/models/contract_artifact.rb
@@ -14,6 +14,14 @@ class ContractArtifact < ApplicationRecord
     ) 
   }
   
+  scope :oldest_first, -> {
+    order(
+      block_number: :asc,
+      transaction_index: :asc,
+      internal_transaction_index: :asc
+    )
+  }
+  
   attr_accessor :abi
   
   after_find :verify_ast_and_hash

--- a/app/models/contract_call.rb
+++ b/app/models/contract_call.rb
@@ -19,6 +19,12 @@ class ContractCall < ApplicationRecord
     internal_transaction_index: :desc
   ) }
 
+  scope :oldest_first, -> { order(
+    block_number: :asc,
+    transaction_index: :asc,
+    internal_transaction_index: :asc
+  ) }
+  
   def execute!
     self.pending_logs = []
     
@@ -92,6 +98,7 @@ class ContractCall < ApplicationRecord
       transaction_hash: TransactionContext.transaction_hash.value,
       block_number: TransactionContext.block.number.value,
       transaction_index: TransactionContext.transaction_index,
+      internal_transaction_index: internal_transaction_index,
       address: calculate_new_contract_address
     )
     

--- a/app/models/contract_state.rb
+++ b/app/models/contract_state.rb
@@ -8,7 +8,11 @@ class ContractState < ApplicationRecord
   optional: true
   
   scope :newest_first, -> {
-    order(block_number: :desc, transaction_index: :desc) 
+    order(block_number: :desc, transaction_index: :desc, contract_address: :desc)
+  }
+  
+  scope :oldest_first, -> {
+    order(block_number: :asc, transaction_index: :asc, contract_address: :asc)
   }
   
   def as_json(options = {})

--- a/app/models/contract_transaction.rb
+++ b/app/models/contract_transaction.rb
@@ -8,6 +8,9 @@ class ContractTransaction < ApplicationRecord
   has_many :contracts, foreign_key: :transaction_hash, primary_key: :transaction_hash
   has_many :contract_artifacts, foreign_key: :transaction_hash, primary_key: :transaction_hash
 
+  scope :oldest_first, -> { order(block_number: :asc, transaction_index: :asc) }
+  scope :newest_first, -> { order(block_number: :desc, transaction_index: :desc) }
+  
   attr_accessor :tx_origin, :payload
   
   def self.transaction_mimetype

--- a/app/models/state_attestation.rb
+++ b/app/models/state_attestation.rb
@@ -71,7 +71,7 @@ class StateAttestation < ApplicationRecord
   end
   
   def hashable_attributes(klass)
-    klass.column_names - ['id', 'updated_at', 'created_at']
+    (klass.column_names - ['id', 'updated_at', 'created_at']).sort
   end
   
   def quoted_hashable_attributes(klass)

--- a/app/models/state_attestation.rb
+++ b/app/models/state_attestation.rb
@@ -1,0 +1,82 @@
+class StateAttestation < ApplicationRecord
+  belongs_to :eth_block, foreign_key: :block_number, primary_key: :block_number, optional: true
+  
+  has_many :ethscriptions, primary_key: :block_number, foreign_key: :block_number
+  has_many :contracts, primary_key: :block_number, foreign_key: :block_number
+  has_many :transaction_receipts, primary_key: :block_number, foreign_key: :block_number
+  has_many :contract_transactions, primary_key: :block_number, foreign_key: :block_number
+  has_many :system_config_versions, primary_key: :block_number, foreign_key: :block_number
+  has_many :contract_states, primary_key: :block_number, foreign_key: :block_number
+  has_many :contract_artifacts, primary_key: :block_number, foreign_key: :block_number
+  has_many :contract_calls, primary_key: :block_number, foreign_key: :block_number
+  
+  def self.create_next_attestations!(batch_size)
+    batch_size.times do |i|
+      create_next_attestation!
+    end
+  end
+  
+  def self.create_next_attestation!
+    StateAttestation.transaction do
+      next_block_number = if StateAttestation.exists?
+        StateAttestation.maximum(:block_number) + 1
+      else
+        EthBlock.processed.minimum(:block_number)
+      end
+      
+      locked_next_block = EthBlock.processed.where(block_number: next_block_number)
+        .lock("FOR UPDATE SKIP LOCKED")
+        .first
+      
+      return unless locked_next_block
+        
+      create_for_block!(locked_next_block.block_number)
+    end
+  end
+  
+  def self.create_for_block!(block_number)
+    prev_attestation = StateAttestation.find_by(block_number: block_number - 1)
+    
+    record = new(
+      parent_state_hash: prev_attestation&.parent_state_hash,
+      block_number: block_number
+    )
+    
+    record.generate_attestation_hash
+    record.save!
+  end
+  
+  def generate_attestation_hash
+    hash = Digest::SHA256.new
+    hash << (parent_state_hash || "NULL")
+  
+    associations_to_hash.each do |association|
+      hashable_attributes = quoted_hashable_attributes(association.klass)
+      records = association_scope(association).pluck(*hashable_attributes)
+      
+      records.map! { |record| record.nil? ? 'NULL' : record }
+      hash << records.join
+    end
+  
+    self.state_hash = "0x" + hash.hexdigest
+  end
+  
+  def association_scope(association)
+    association.klass.oldest_first.where(block_number: block_number)
+  end
+  
+  def associations_to_hash
+    self.class.reflect_on_all_associations(:has_many) +
+    [self.class.reflect_on_association(:eth_block)]
+  end
+  
+  def hashable_attributes(klass)
+    klass.column_names - ['id', 'updated_at', 'created_at']
+  end
+  
+  def quoted_hashable_attributes(klass)
+    hashable_attributes(klass).map do |attr|
+      "md5(#{klass.connection.quote_column_name(attr)}::text)"
+    end
+  end
+end

--- a/app/models/system_config_version.rb
+++ b/app/models/system_config_version.rb
@@ -8,6 +8,10 @@ class SystemConfigVersion < ApplicationRecord
     order(block_number: :desc, transaction_index: :desc) 
   }
   
+  scope :oldest_first, -> {
+    order(block_number: :asc, transaction_index: :asc)
+  }
+  
   def self.latest_tx_hash
     newest_first.limit(1).pluck(:transaction_hash).first
   end

--- a/config/state_attestation_clock.rb
+++ b/config/state_attestation_clock.rb
@@ -1,0 +1,27 @@
+require 'clockwork'
+require './config/boot'
+require './config/environment'
+require 'active_support/time'
+
+module Clockwork
+  handler do |job|
+    puts "Running #{job}"
+  end
+
+  error_handler do |error|
+    report_exception_every = 15.minutes
+    
+    exception_key = ["clockwork-airbrake", error.class, error.message, error.backtrace[0]].to_cache_key
+    
+    last_reported_at = Rails.cache.read(exception_key)
+
+    if last_reported_at.blank? || (Time.zone.now - last_reported_at > report_exception_every)
+      Airbrake.notify(error)
+      Rails.cache.write(exception_key, Time.zone.now)
+    end
+  end
+
+  every(5.seconds, 'Process state attestations') do
+    StateAttestation.create_next_attestations!(1000)
+  end
+end

--- a/db/migrate/20230824165302_create_ethscriptions.rb
+++ b/db/migrate/20230824165302_create_ethscriptions.rb
@@ -17,6 +17,7 @@ class CreateEthscriptions < ActiveRecord::Migration[7.1]
       t.bigint :gas_used
       t.bigint :transaction_fee
       
+      t.index :block_number
       t.index [:block_number, :transaction_index], unique: true
       t.index :transaction_hash, unique: true
       t.index :processing_state

--- a/db/migrate/20230824170608_create_contracts.rb
+++ b/db/migrate/20230824170608_create_contracts.rb
@@ -4,12 +4,14 @@ class CreateContracts < ActiveRecord::Migration[7.1]
       t.string :transaction_hash, null: false
       t.bigint :block_number, null: false
       t.bigint :transaction_index, null: false
+      t.bigint :internal_transaction_index, null: false
       t.string :current_type
       t.string :current_init_code_hash
       t.jsonb :current_state, default: {}, null: false
       t.string :address, null: false
       t.boolean :deployed_successfully, null: false
     
+      t.index :block_number
       t.index :deployed_successfully
       t.index [:deployed_successfully, :address], unique: true
       t.index :address, where: "(deployed_successfully = true)", unique: true, name: :idx_on_address_deployed_successfully

--- a/db/migrate/20230824171752_create_contract_states.rb
+++ b/db/migrate/20230824171752_create_contract_states.rb
@@ -9,6 +9,7 @@ class CreateContractStates < ActiveRecord::Migration[7.1]
       t.bigint :transaction_index, null: false
       t.string :contract_address, null: false
     
+      t.index :block_number
       t.index [:contract_address, :transaction_hash], unique: true
       t.index [:contract_address, :block_number, :transaction_index], unique: true,
         name: :index_contract_states_on_addr_block_number_tx_index

--- a/db/migrate/20230824174640_create_contract_transactions.rb
+++ b/db/migrate/20230824174640_create_contract_transactions.rb
@@ -7,6 +7,7 @@ class CreateContractTransactions < ActiveRecord::Migration[7.1]
       t.bigint :block_number, null: false
       t.bigint :transaction_index, null: false
     
+      t.index :block_number
       t.index [:block_number, :transaction_index], unique: true, name: :index_contract_txs_on_block_number_and_tx_index
       t.index :transaction_hash, unique: true
     

--- a/db/migrate/20230824174646_create_contract_calls.rb
+++ b/db/migrate/20230824174646_create_contract_calls.rb
@@ -22,6 +22,7 @@ class CreateContractCalls < ActiveRecord::Migration[7.1]
       t.datetime :end_time, null: false
       t.integer :runtime_ms, null: false
     
+      t.index :block_number
       t.index [:block_number, :transaction_index, :internal_transaction_index], unique: true, name: :idx_on_block_number_txi_internal_txi
       t.index :call_type
       t.index :created_contract_address, unique: true

--- a/db/migrate/20231110173854_create_contract_artifacts.rb
+++ b/db/migrate/20231110173854_create_contract_artifacts.rb
@@ -12,6 +12,7 @@ class CreateContractArtifacts < ActiveRecord::Migration[7.1]
       t.string :pragma_language, null: false
       t.string :pragma_version, null: false
     
+      t.index :block_number
       t.index [:block_number, :transaction_index, :internal_transaction_index], unique: true
       t.index [:transaction_hash, :internal_transaction_index], unique: true
       t.index :init_code_hash, unique: true

--- a/db/migrate/20231113223006_create_system_config_versions.rb
+++ b/db/migrate/20231113223006_create_system_config_versions.rb
@@ -8,6 +8,7 @@ class CreateSystemConfigVersions < ActiveRecord::Migration[7.1]
       t.bigint :start_block_number
       t.string :admin_address
     
+      t.index :block_number
       t.index [:block_number, :transaction_index], unique: true
       t.index :transaction_hash, unique: true
     

--- a/db/migrate/20231203153159_create_state_attestations.rb
+++ b/db/migrate/20231203153159_create_state_attestations.rb
@@ -1,0 +1,61 @@
+class CreateStateAttestations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :state_attestations do |t|
+      t.bigint :block_number, null: false
+      t.string :state_hash, null: false
+      t.string :parent_state_hash
+      
+      t.index :block_number, unique: true
+      t.index :state_hash, unique: true
+      t.index :parent_state_hash, unique: true
+      
+      t.check_constraint "state_hash ~ '^0x[a-f0-9]{64}$'"
+      t.check_constraint "parent_state_hash IS NULL OR parent_state_hash ~ '^0x[a-f0-9]{64}$'"
+      
+      t.foreign_key :eth_blocks, column: :block_number, primary_key: :block_number, on_delete: :cascade
+      
+      t.timestamps
+    end
+    
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION check_attestation_order()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        IF (SELECT MAX(block_number) FROM state_attestations) IS NOT NULL THEN
+          IF NEW.block_number <> (SELECT MAX(block_number) + 1 FROM state_attestations) THEN
+            RAISE EXCEPTION 'New block number must be equal to max block number + 1';
+          END IF;
+          IF NEW.parent_state_hash <> (SELECT state_hash FROM state_attestations WHERE block_number = NEW.block_number - 1) THEN
+            RAISE EXCEPTION 'Parent state hash must match the state hash of the previous block';
+          END IF;
+        ELSE
+          IF NEW.parent_state_hash IS NOT NULL THEN
+            RAISE EXCEPTION 'Parent state hash of the first record must be NULL';
+          END IF;
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER trigger_check_attestation_order
+      BEFORE INSERT ON state_attestations
+      FOR EACH ROW EXECUTE FUNCTION check_attestation_order();
+    SQL
+    
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION check_block_processing_state()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        IF (SELECT processing_state FROM eth_blocks WHERE block_number = NEW.block_number) = 'pending' THEN
+          RAISE EXCEPTION 'Cannot create a StateAttestation for a block with processing state pending';
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      CREATE TRIGGER trigger_check_block_processing_state
+      BEFORE INSERT ON state_attestations
+      FOR EACH ROW EXECUTE FUNCTION check_block_processing_state();
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,31 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: check_attestation_order(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.check_attestation_order() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+      BEGIN
+        IF (SELECT MAX(block_number) FROM state_attestations) IS NOT NULL THEN
+          IF NEW.block_number <> (SELECT MAX(block_number) + 1 FROM state_attestations) THEN
+            RAISE EXCEPTION 'New block number must be equal to max block number + 1';
+          END IF;
+          IF NEW.parent_state_hash <> (SELECT state_hash FROM state_attestations WHERE block_number = NEW.block_number - 1) THEN
+            RAISE EXCEPTION 'Parent state hash must match the state hash of the previous block';
+          END IF;
+        ELSE
+          IF NEW.parent_state_hash IS NOT NULL THEN
+            RAISE EXCEPTION 'Parent state hash of the first record must be NULL';
+          END IF;
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+
+
+--
 -- Name: check_block_order(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -19,6 +44,22 @@ CREATE FUNCTION public.check_block_order() RETURNS trigger
       BEGIN
         IF (SELECT MAX(block_number) FROM eth_blocks) IS NOT NULL AND (NEW.block_number <> (SELECT MAX(block_number) + 1 FROM eth_blocks) OR NEW.parent_blockhash <> (SELECT blockhash FROM eth_blocks WHERE block_number = NEW.block_number - 1)) THEN
           RAISE EXCEPTION 'New block number must be equal to max block number + 1, or this must be the first block';
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+
+
+--
+-- Name: check_block_processing_state(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.check_block_processing_state() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+      BEGIN
+        IF (SELECT processing_state FROM eth_blocks WHERE block_number = NEW.block_number) = 'pending' THEN
+          RAISE EXCEPTION 'Cannot create a StateAttestation for a block with processing state pending';
         END IF;
         RETURN NEW;
       END;
@@ -346,6 +387,7 @@ CREATE TABLE public.contracts (
     transaction_hash character varying NOT NULL,
     block_number bigint NOT NULL,
     transaction_index bigint NOT NULL,
+    internal_transaction_index bigint NOT NULL,
     current_type character varying,
     current_init_code_hash character varying,
     current_state jsonb DEFAULT '{}'::jsonb NOT NULL,
@@ -481,6 +523,41 @@ ALTER SEQUENCE public.ethscriptions_id_seq OWNED BY public.ethscriptions.id;
 CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
+
+
+--
+-- Name: state_attestations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.state_attestations (
+    id bigint NOT NULL,
+    block_number bigint NOT NULL,
+    state_hash character varying NOT NULL,
+    parent_state_hash character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    CONSTRAINT chk_rails_3ec656a1ee CHECK (((parent_state_hash IS NULL) OR ((parent_state_hash)::text ~ '^0x[a-f0-9]{64}$'::text))),
+    CONSTRAINT chk_rails_e3d9bd2c69 CHECK (((state_hash)::text ~ '^0x[a-f0-9]{64}$'::text))
+);
+
+
+--
+-- Name: state_attestations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.state_attestations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: state_attestations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.state_attestations_id_seq OWNED BY public.state_attestations.id;
 
 
 --
@@ -633,6 +710,13 @@ ALTER TABLE ONLY public.ethscriptions ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: state_attestations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_attestations ALTER COLUMN id SET DEFAULT nextval('public.state_attestations_id_seq'::regclass);
+
+
+--
 -- Name: system_config_versions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -719,6 +803,14 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
+-- Name: state_attestations state_attestations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_attestations
+    ADD CONSTRAINT state_attestations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: system_config_versions system_config_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -777,6 +869,13 @@ CREATE UNIQUE INDEX idx_on_tx_hash_internal_txi ON public.contract_calls USING b
 
 
 --
+-- Name: index_contract_artifacts_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contract_artifacts_on_block_number ON public.contract_artifacts USING btree (block_number);
+
+
+--
 -- Name: index_contract_artifacts_on_init_code_hash; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -788,6 +887,13 @@ CREATE UNIQUE INDEX index_contract_artifacts_on_init_code_hash ON public.contrac
 --
 
 CREATE INDEX index_contract_artifacts_on_name ON public.contract_artifacts USING btree (name);
+
+
+--
+-- Name: index_contract_calls_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contract_calls_on_block_number ON public.contract_calls USING btree (block_number);
 
 
 --
@@ -847,6 +953,13 @@ CREATE UNIQUE INDEX index_contract_states_on_addr_block_number_tx_index ON publi
 
 
 --
+-- Name: index_contract_states_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contract_states_on_block_number ON public.contract_states USING btree (block_number);
+
+
+--
 -- Name: index_contract_states_on_contract_address; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -875,6 +988,13 @@ CREATE INDEX index_contract_states_on_transaction_hash ON public.contract_states
 
 
 --
+-- Name: index_contract_transactions_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contract_transactions_on_block_number ON public.contract_transactions USING btree (block_number);
+
+
+--
 -- Name: index_contract_transactions_on_transaction_hash; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -900,6 +1020,13 @@ CREATE UNIQUE INDEX index_contract_txs_on_block_number_and_tx_index ON public.co
 --
 
 CREATE UNIQUE INDEX index_contracts_on_address ON public.contracts USING btree (address);
+
+
+--
+-- Name: index_contracts_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contracts_on_block_number ON public.contracts USING btree (block_number);
 
 
 --
@@ -1008,6 +1135,13 @@ CREATE INDEX index_eth_blocks_on_timestamp ON public.eth_blocks USING btree ("ti
 
 
 --
+-- Name: index_ethscriptions_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ethscriptions_on_block_number ON public.ethscriptions USING btree (block_number);
+
+
+--
 -- Name: index_ethscriptions_on_block_number_and_transaction_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1026,6 +1160,34 @@ CREATE INDEX index_ethscriptions_on_processing_state ON public.ethscriptions USI
 --
 
 CREATE UNIQUE INDEX index_ethscriptions_on_transaction_hash ON public.ethscriptions USING btree (transaction_hash);
+
+
+--
+-- Name: index_state_attestations_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_state_attestations_on_block_number ON public.state_attestations USING btree (block_number);
+
+
+--
+-- Name: index_state_attestations_on_parent_state_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_state_attestations_on_parent_state_hash ON public.state_attestations USING btree (parent_state_hash);
+
+
+--
+-- Name: index_state_attestations_on_state_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_state_attestations_on_state_hash ON public.state_attestations USING btree (state_hash);
+
+
+--
+-- Name: index_system_config_versions_on_block_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_system_config_versions_on_block_number ON public.system_config_versions USING btree (block_number);
 
 
 --
@@ -1099,10 +1261,24 @@ CREATE TRIGGER check_status_trigger BEFORE INSERT OR UPDATE OF status ON public.
 
 
 --
+-- Name: state_attestations trigger_check_attestation_order; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_check_attestation_order BEFORE INSERT ON public.state_attestations FOR EACH ROW EXECUTE FUNCTION public.check_attestation_order();
+
+
+--
 -- Name: eth_blocks trigger_check_block_order; Type: TRIGGER; Schema: public; Owner: -
 --
 
 CREATE TRIGGER trigger_check_block_order BEFORE INSERT ON public.eth_blocks FOR EACH ROW EXECUTE FUNCTION public.check_block_order();
+
+
+--
+-- Name: state_attestations trigger_check_block_processing_state; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_check_block_processing_state BEFORE INSERT ON public.state_attestations FOR EACH ROW EXECUTE FUNCTION public.check_block_processing_state();
 
 
 --
@@ -1156,6 +1332,14 @@ ALTER TABLE ONLY public.transaction_receipts
 
 ALTER TABLE ONLY public.contract_states
     ADD CONSTRAINT fk_rails_54fdb5b7e7 FOREIGN KEY (transaction_hash) REFERENCES public.ethscriptions(transaction_hash) ON DELETE CASCADE;
+
+
+--
+-- Name: state_attestations fk_rails_680e4dd75e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_attestations
+    ADD CONSTRAINT fk_rails_680e4dd75e FOREIGN KEY (block_number) REFERENCES public.eth_blocks(block_number) ON DELETE CASCADE;
 
 
 --
@@ -1261,6 +1445,7 @@ ALTER TABLE ONLY public.contract_calls
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20231203153159'),
 ('20231113223006'),
 ('20231110173854'),
 ('20230824174647'),

--- a/spec/models/contract_state_spec.rb
+++ b/spec/models/contract_state_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe Contract, type: :model do
       updated_at: Time.now,
       address: '0x' + SecureRandom.hex(20),
       current_state: {},
-      deployed_successfully: true
+      deployed_successfully: true,
+      internal_transaction_index: 0
     )
   end
 


### PR DESCRIPTION
To determine if two indexers have the same data.

We include all model data in the hash except for ids, and Rails-created timestamps. We use the MD5 hash in the database because it's there by default, it's faster, and we don't need a high-level of cryptographic security for this use-case.