### PR TITLE
Use existing data for buddy address prediction

### DIFF
--- a/app/models/contracts/FacetBuddyFactory.rubidity
+++ b/app/models/contracts/FacetBuddyFactory.rubidity
@@ -63,6 +63,12 @@ contract :FacetBuddyFactory, is: [:Upgradeable], upgradeable: true do
   end
   
   function :predictBuddyAddress, { forUser: :address }, :public, :view, returns: :address do
+    existing = s.buddyForUser[forUser]
+    
+    if existing != address(0)
+      return existing
+    end
+    
     return create2_address(
       salt: keccak256(abi.encodePacked(forUser)),
       deployer: address(this),


### PR DESCRIPTION
The issue with calculating it is that the calculation depends on the init code hash of the buddy which could change. This would lead to incorrect address predictions for existing buddy contracts.