### PR TITLE
Ability to simulate transactions with state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 .env*
 
 .DS_Store
+*.sqlite3*

--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,5 @@ gem 'facet_rails_common', git: 'https://github.com/0xfacet/facet_rails_common.gi
 
 gem 'rswag-api'
 gem 'rswag-ui'
+
+gem "sqlite3", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,9 @@ GEM
       parser
     scrypt (3.0.7)
       ffi-compiler (>= 1.0, < 2.0)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     stackprof (0.2.26)
     stringio (3.0.8)
     thor (1.2.2)
@@ -345,6 +348,7 @@ DEPENDENCIES
   rswag-specs
   rswag-ui
   scout_apm (~> 5.3)
+  sqlite3 (~> 1.7)
   stackprof
   tzinfo-data
   unparser

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,4 +6,37 @@ class ApplicationRecord < ActiveRecord::Base
   else
     connects_to database: { writing: :primary }
   end
+  
+  private
+  
+  def self.with_temporary_database_environment
+    original_connection_config = ActiveRecord::Base.connection_db_config.configuration_hash
+    original_verbose = ActiveRecord::Migration.verbose
+  
+    ActiveRecord::Migration.verbose = false
+    ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+    ApplicationRecord.descendants.reject(&:abstract_class?).each do |model|
+      model.reset_column_information if model.connected?
+      model.reset_sequence_name
+    end
+  
+    migrations_paths = Rails.root.join('db', 'migrate')
+    context = ActiveRecord::MigrationContext.new(migrations_paths)
+    context.migrate
+  
+    yield
+  ensure
+    ActiveRecord::Base.connection.close if ActiveRecord::Base.connection&.active?
+    ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+    ActiveRecord::Base.establish_connection(original_connection_config)
+    ActiveRecord::Migration.verbose = original_verbose
+    ApplicationRecord.descendants.reject(&:abstract_class?).each do |model|
+      model.reset_column_information if model.connected?
+      model.reset_sequence_name
+    end
+  end
+  
+  def using_postgres?
+    ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
+  end
 end

--- a/app/models/contract_state.rb
+++ b/app/models/contract_state.rb
@@ -10,6 +10,10 @@ class ContractState < ApplicationRecord
     order(Arel.sql(order_clause))
   }
   
+  after_create :update_contract_on_create, unless: :using_postgres?
+  # TODO: make re-org safe
+  after_destroy :update_contract_on_destroy, unless: :using_postgres?
+  
   def as_json(options = {})
     super(
       options.merge(
@@ -20,5 +24,39 @@ class ContractState < ApplicationRecord
         ]
       )
     )
+  end
+  
+  def update_contract_on_create
+    # TODO: do it all in SQL
+    latest_state = ContractState.where(contract_address: contract_address)
+                                .order(block_number: :desc)
+                                .first
+
+    contract.update!(
+      current_state: latest_state.state,
+      current_type: latest_state.type,
+      current_init_code_hash: latest_state.init_code_hash
+    )
+  end
+
+  def update_contract_on_destroy
+    latest_state = ContractState.where(contract_address: contract_address)
+                                .where.not(id: id)
+                                .order(block_number: :desc)
+                                .first
+
+    if latest_state.present?
+      contract.update!(
+        current_state: latest_state.state,
+        current_type: latest_state.type,
+        current_init_code_hash: latest_state.init_code_hash,
+      )
+    else
+      contract.update!(
+        current_state: {},
+        current_type: nil,
+        current_init_code_hash: nil,
+      )
+    end
   end
 end

--- a/app/models/system_config_version.rb
+++ b/app/models/system_config_version.rb
@@ -9,6 +9,8 @@ class SystemConfigVersion < ApplicationRecord
     order(block_number: :desc, transaction_index: :desc) 
   }
   
+  attr_accessor :all_contracts_supported
+  
   def self.latest_tx_hash
     newest_first.limit(1).pluck(:transaction_hash).first
   end
@@ -75,7 +77,7 @@ class SystemConfigVersion < ApplicationRecord
   end
   
   def contract_supported?(init_code_hash)
-    supported_contracts.include?(init_code_hash)
+    all_contracts_supported || supported_contracts.include?(init_code_hash)
   end
   
   def self.current_supported_contract_artifacts

--- a/config/initializers/migration_extensions.rb
+++ b/config/initializers/migration_extensions.rb
@@ -1,0 +1,11 @@
+module MigrationExtensions
+  def sqlite_adapter?
+    ActiveRecord::Base.connection.adapter_name.downcase == 'sqlite3'
+  end
+
+  def pg_adapter?
+    ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
+  end
+end
+
+ActiveRecord::Migration.prepend(MigrationExtensions)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,8 @@ Rails.application.routes.draw do
         get "/simulate", to: "contracts#simulate_transaction"
         post "/simulate", to: "contracts#simulate_transaction"
         
+        post "/simulate_with_state", to: "contracts#simulate_transaction_with_state"
+        
         get "/all-abis", to: "contracts#all_abis"
         get "/supported-contract-artifacts", to: "contracts#supported_contract_artifacts"
         get "/deployable-contracts", to: "contracts#deployable_contracts"

--- a/db/migrate/20230824165302_create_ethscriptions.rb
+++ b/db/migrate/20230824165302_create_ethscriptions.rb
@@ -21,10 +21,12 @@ class CreateEthscriptions < ActiveRecord::Migration[7.1]
       t.index :transaction_hash, unique: true
       t.index :processing_state
     
-      t.check_constraint "block_blockhash ~ '^0x[a-f0-9]{64}$'"
-      t.check_constraint "creator ~ '^0x[a-f0-9]{40}$'"
-      t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
-      t.check_constraint "initial_owner ~ '^0x[a-f0-9]{40}$'"
+      if pg_adapter?
+        t.check_constraint "block_blockhash ~ '^0x[a-f0-9]{64}$'"
+        t.check_constraint "creator ~ '^0x[a-f0-9]{40}$'"
+        t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
+        t.check_constraint "initial_owner ~ '^0x[a-f0-9]{40}$'"
+      end
     
       t.check_constraint "processing_state IN ('pending', 'success', 'failure')"
       
@@ -34,6 +36,8 @@ class CreateEthscriptions < ActiveRecord::Migration[7.1]
       
       t.timestamps
     end    
+    
+    return unless pg_adapter?
     
     execute <<-SQL
       CREATE OR REPLACE FUNCTION check_ethscription_order()

--- a/db/migrate/20230824170608_create_contracts.rb
+++ b/db/migrate/20230824170608_create_contracts.rb
@@ -6,7 +6,7 @@ class CreateContracts < ActiveRecord::Migration[7.1]
       t.bigint :transaction_index, null: false
       t.string :current_type
       t.string :current_init_code_hash
-      t.jsonb :current_state, default: {}, null: false
+      t.column :current_state, :jsonb, default: {}, null: false
       t.string :address, null: false
       t.boolean :deployed_successfully, null: false
     
@@ -18,9 +18,11 @@ class CreateContracts < ActiveRecord::Migration[7.1]
       t.index :current_type
       t.index :transaction_hash
     
-      t.check_constraint "address ~ '^0x[a-f0-9]{40}$'"
-      t.check_constraint "current_init_code_hash ~ '^0x[a-f0-9]{64}$'"
-      t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
+      if pg_adapter?
+        t.check_constraint "address ~ '^0x[a-f0-9]{40}$'"
+        t.check_constraint "current_init_code_hash ~ '^0x[a-f0-9]{64}$'"
+        t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
+      end
     
       t.foreign_key :ethscriptions, column: :transaction_hash, primary_key: :transaction_hash, on_delete: :cascade
       t.foreign_key :eth_blocks, column: :block_number, primary_key: :block_number, on_delete: :cascade

--- a/db/migrate/20230824171752_create_contract_states.rb
+++ b/db/migrate/20230824171752_create_contract_states.rb
@@ -3,21 +3,25 @@ class CreateContractStates < ActiveRecord::Migration[7.1]
     create_table :contract_states, force: :cascade do |t|
       t.string :type, null: false
       t.string :init_code_hash, null: false
-      t.jsonb :state, default: {}, null: false
+      t.column :state, :jsonb, default: {}, null: false
       t.bigint :block_number, null: false
       t.string :contract_address, null: false
     
       t.index :block_number
       t.index :contract_address
     
-      t.check_constraint "contract_address ~ '^0x[a-f0-9]{40}$'"
-      t.check_constraint "init_code_hash ~ '^0x[a-f0-9]{64}$'"
+      if pg_adapter?
+        t.check_constraint "contract_address ~ '^0x[a-f0-9]{40}$'"
+        t.check_constraint "init_code_hash ~ '^0x[a-f0-9]{64}$'"
+      end
     
       t.foreign_key :contracts, column: :contract_address, primary_key: :address, on_delete: :cascade
       t.foreign_key :eth_blocks, column: :block_number, primary_key: :block_number, on_delete: :cascade
       
       t.timestamps
     end
+    
+    return unless pg_adapter?
         
     execute <<-SQL
       CREATE OR REPLACE FUNCTION update_current_state() RETURNS TRIGGER AS $$

--- a/db/migrate/20230824174640_create_contract_transactions.rb
+++ b/db/migrate/20230824174640_create_contract_transactions.rb
@@ -10,8 +10,10 @@ class CreateContractTransactions < ActiveRecord::Migration[7.1]
       t.index [:block_number, :transaction_index], unique: true, name: :index_contract_txs_on_block_number_and_tx_index
       t.index :transaction_hash, unique: true
     
-      t.check_constraint "block_blockhash ~ '^0x[a-f0-9]{64}$'"
-      t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
+      if pg_adapter?
+        t.check_constraint "block_blockhash ~ '^0x[a-f0-9]{64}$'"
+        t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
+      end
     
       t.foreign_key :ethscriptions, column: :transaction_hash, primary_key: :transaction_hash, on_delete: :cascade
       t.foreign_key :eth_blocks, column: :block_number, primary_key: :block_number, on_delete: :cascade

--- a/db/migrate/20231110173854_create_contract_artifacts.rb
+++ b/db/migrate/20231110173854_create_contract_artifacts.rb
@@ -8,7 +8,7 @@ class CreateContractArtifacts < ActiveRecord::Migration[7.1]
       t.string :name, null: false
       t.text :source_code, null: false
       t.string :init_code_hash, null: false
-      t.jsonb :references, default: [], null: false
+      t.column :references, :jsonb, default: [], null: false
       t.string :pragma_language, null: false
       t.string :pragma_version, null: false
     
@@ -17,7 +17,9 @@ class CreateContractArtifacts < ActiveRecord::Migration[7.1]
       t.index :init_code_hash, unique: true
       t.index :name
     
-      t.check_constraint "init_code_hash ~ '^0x[a-f0-9]{64}$'"
+      if pg_adapter?
+        t.check_constraint "init_code_hash ~ '^0x[a-f0-9]{64}$'"
+      end
     
       t.foreign_key :ethscriptions, column: :transaction_hash, primary_key: :transaction_hash, on_delete: :cascade
       t.foreign_key :eth_blocks, column: :block_number, primary_key: :block_number, on_delete: :cascade

--- a/db/migrate/20231113223006_create_system_config_versions.rb
+++ b/db/migrate/20231113223006_create_system_config_versions.rb
@@ -4,15 +4,17 @@ class CreateSystemConfigVersions < ActiveRecord::Migration[7.1]
       t.string :transaction_hash, null: false
       t.bigint :block_number, null: false
       t.bigint :transaction_index, null: false
-      t.jsonb :supported_contracts, default: [], null: false
+      t.column :supported_contracts, :jsonb, default: [], null: false
       t.bigint :start_block_number
       t.string :admin_address
     
       t.index [:block_number, :transaction_index], unique: true
       t.index :transaction_hash, unique: true
     
-      t.check_constraint "admin_address ~ '^0x[a-f0-9]{40}$'"
-      t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
+      if pg_adapter?
+        t.check_constraint "admin_address ~ '^0x[a-f0-9]{40}$'"
+        t.check_constraint "transaction_hash ~ '^0x[a-f0-9]{64}$'"
+      end
       
       t.foreign_key :ethscriptions, column: :transaction_hash, primary_key: :transaction_hash, on_delete: :cascade
       t.foreign_key :eth_blocks, column: :block_number, primary_key: :block_number, on_delete: :cascade

--- a/db/migrate/20240309162632_remove_check_last_state_trigger_and_function.rb
+++ b/db/migrate/20240309162632_remove_check_last_state_trigger_and_function.rb
@@ -1,5 +1,7 @@
 class RemoveCheckLastStateTriggerAndFunction < ActiveRecord::Migration[7.1]
   def up
+    return unless pg_adapter?
+    
     execute <<-SQL
       DROP TRIGGER IF EXISTS check_before_delete ON contract_states;
       DROP FUNCTION IF EXISTS check_last_state();
@@ -7,6 +9,8 @@ class RemoveCheckLastStateTriggerAndFunction < ActiveRecord::Migration[7.1]
   end
 
   def down
+    return unless pg_adapter?
+    
     execute <<-SQL
       CREATE OR REPLACE FUNCTION check_last_state() RETURNS TRIGGER AS $$
       DECLARE

--- a/lib/rubidity/transaction_execution/block_context.rb
+++ b/lib/rubidity/transaction_execution/block_context.rb
@@ -95,6 +95,10 @@ class BlockContext < ActiveSupport::CurrentAttributes
     end.compact
     
     ContractState.import!(states_to_save)
+    
+    states_to_save.each do |state|
+      state.run_callbacks(:create)
+    end
   end
   
   def start_block_passed?

--- a/spec/models/simulate_with_state_spec.rb
+++ b/spec/models/simulate_with_state_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+describe 'Simulate with state' do
+  let(:alice) { "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+  let(:bob) { "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }
+  
+  it 'simulates' do
+    contract = RubidityTranspiler.transpile_and_get("PublicMintERC20")
+
+    resp = ContractTransaction.simulate_transaction_with_state(
+      from: alice,
+      tx_payload: {
+        op: :create,
+        data: {
+          source_code: contract.source_code,
+          init_code_hash: contract.init_code_hash,
+          args: {
+            name: "Public Mint ERC20",
+            symbol: "PMINT",
+            maxSupply: 1000000000000000000000000000,
+            perMintLimit: 1000000000000000000000000,
+            decimals: 18
+          }
+        }
+      }
+    )
+    
+    deployed_address = resp[:transaction_receipt]['effective_contract_address']
+    
+    expect(resp[:transaction_receipt][:status]).to eq('success')
+    
+    expect(resp[:state][:contracts].length).to eq(1)
+    expect(resp[:state][:contracts].first['current_state']).to eq(
+          {
+            "name" => "Public Mint ERC20",
+          "symbol" => "PMINT",
+        "decimals" => 18,
+    "totalSupply" => 0,
+      "balanceOf" => {},
+      "allowance" => {},
+      "maxSupply" => 1000000000000000000000000000,
+    "perMintLimit" => 1000000000000000000000000
+          }
+    )
+    {      from: alice,
+      tx_payload: {
+        op: :call,
+        data: {
+          to: deployed_address,
+          function: 'mint',
+          args: 100
+        }
+      },
+      initial_state: resp[:state]}.to_json.pbcopy
+    exit
+    resp = ContractTransaction.simulate_transaction_with_state(
+      from: alice,
+      tx_payload: {
+        op: :call,
+        data: {
+          to: deployed_address,
+          function: 'mint',
+          args: 100
+        }
+      },
+      initial_state: resp[:state]
+    )
+    
+    expect(resp[:transaction_receipt][:status]).to eq('success')
+
+    expect(resp[:state][:contracts].first['current_state']['balanceOf'][alice]).to eq(100)
+    
+    resp = ContractTransaction.simulate_transaction_with_state(
+      from: bob,
+      tx_payload: {
+        op: :call,
+        data: {
+          to: deployed_address,
+          function: 'mint',
+          args: 234234234
+        }
+      },
+      initial_state: resp[:state]
+    )
+    
+    expect(resp[:transaction_receipt][:status]).to eq('success')
+
+    expect(resp[:state][:contracts].first['current_state']['balanceOf'][bob]).to eq(234234234)
+    expect(resp[:state][:contracts].first['current_state']['totalSupply']).to eq(234234234 + 100)
+    
+    expect(Contract.count).to eq(0)
+  end
+end


### PR DESCRIPTION
Adds a new controller action `/contracts/simulate_with_state`. In addition to the usual simulation params the user provides the current state the simulation should run in. This is an object with the following keys: `["eth_blocks", "ethscriptions", "contract_transactions", "contract_calls", "contract_artifacts", "contracts"]`.

Then, when the simulation is complete, the user is returned not only the transaction receipt but also the new world state. The user can then pass the new world state in for a subsequent call.