### PR TITLE
Ability to have multiple image URIs on an upgrade level

### DIFF
--- a/app/models/contracts/TokenUpgradeRenderer02.rubidity
+++ b/app/models/contracts/TokenUpgradeRenderer02.rubidity
@@ -90,6 +90,7 @@ contract :TokenUpgradeRenderer02, is: :Upgradeable, upgradeable: true do
     require(newLevel.endTime > newLevel.startTime, "End time must be after start time")
     require(newLevel.startTime > lastLevel.endTime, "Start time must be after last level end time")
     require(s.tokenUpgradeLevelsByCollection[collection].length + 1 <= s.maxUpgradeLevelCount, "Max upgrade level count reached")
+    require(imageURIs.length <= 25, "Max 25 image URIs allowed")
     
     s.tokenUpgradeLevelsByCollection[collection].push(newLevel)
     
@@ -111,6 +112,8 @@ contract :TokenUpgradeRenderer02, is: :Upgradeable, upgradeable: true do
   
   function :editUpgradeLevel, { collection: :address, index: :uint256, newLevel: :TokenUpgradeLevel, imageURIs: [:string] }, :public do
     requireSenderAdmin(collection)
+    
+    require(imageURIs.length <= 25, "Max 25 image URIs allowed")
     
     editingFirstLevel = index == 0
     editingLastLevel = index == s.tokenUpgradeLevelsByCollection[collection].length - 1

--- a/app/models/contracts/TokenUpgradeRenderer02.rubidity
+++ b/app/models/contracts/TokenUpgradeRenderer02.rubidity
@@ -259,7 +259,7 @@ contract :TokenUpgradeRenderer02, is: :Upgradeable, upgradeable: true do
     
     imageURI = if uriAryLength > 0
       blockhash = s.blockHashByTokenLevelByCollection[collection][status.upgradeLevel]
-      entropy = uint256(keccak256(abi.encodePacked(blockhash, tokenId)))
+      entropy = uint256(keccak256(abi.encodePacked(collection, blockhash, tokenId)))
       
       s.tokenUpgradeLevelImageURIsByCollection[collection][status.upgradeLevel][entropy % uriAryLength]
     else

--- a/app/models/contracts/TokenUpgradeRenderer02.rubidity
+++ b/app/models/contracts/TokenUpgradeRenderer02.rubidity
@@ -1,0 +1,338 @@
+pragma :rubidity, "1.0.0"
+
+import "./Upgradeable.rubidity"
+import "./ERC721.rubidity"
+import "./ERC20.rubidity"
+
+contract :INFTCollection01, abstract: true do
+  function :owner, :external, :view, returns: :address
+end
+
+contract :TokenUpgradeRenderer02, is: :Upgradeable, upgradeable: true do
+  event :CollectionInitialized, {
+    collection: :address,
+    contractInfo: :ContractInfo,
+    initialLevel: :TokenUpgradeLevel
+  }
+  
+  event :UpgradeLevelUpdated, {
+    collection: :address,
+    index: :uint256,
+    name: :string,
+    imageURI: :string,
+    animationURI: :string,
+    startTime: :uint256,
+    endTime: :uint256,
+    newRecord: :bool
+  }
+  
+  event :TokenUpgraded, {
+    collection: :address,
+    tokenId: :uint256,
+    upgradeLevel: :uint256
+  }
+  
+  event :ContractInfoUpdated, {
+    collection: :address,
+    newInfo: :ContractInfo
+  }
+  
+  struct :TokenUpgradeLevel do
+    string :name
+    string :imageURI
+    string :animationURI
+    string :extraAttributesJson
+    uint256 :startTime
+    uint256 :endTime
+  end
+  
+  struct :TokenStatus do
+    uint256 :upgradeLevel
+    uint256 :lastUpgradeTime
+  end
+  
+  struct :ContractInfo do
+    string :name
+    string :description
+    string :imageURI
+  end
+  
+  mapping ({ address: array(:TokenUpgradeLevel, 1) }), :public, :tokenUpgradeLevelsByCollection
+  mapping ({ address: mapping(uint256: :TokenStatus) }), :public, :tokenStatusByCollection
+  mapping ({ address: :ContractInfo }), :public, :contractInfoByCollection
+  
+  mapping ({ address: mapping(uint256: array(:string)) }), :public, :tokenUpgradeLevelImageURIsByCollection
+  mapping ({ address: mapping(uint256: :bytes32) }), :public, :blockHashByTokenLevelByCollection
+  
+  uint256 :public, :perUpgradeFee
+  address :public, :feeTo
+  address :public, :WETH
+  uint256 :public, :maxUpgradeLevelCount
+  
+  constructor(
+    perUpgradeFee: :uint256,
+    feeTo: :address,
+    weth: :address
+  ) {
+    Upgradeable.constructor(upgradeAdmin: msg.sender)
+    
+    s.maxUpgradeLevelCount = 30
+    s.perUpgradeFee = perUpgradeFee
+    s.feeTo = feeTo
+    s.WETH = weth
+  }
+  
+  function :addUpgradeLevel, { collection: :address, newLevel: :TokenUpgradeLevel, imageURIs: [:string] }, :public do
+    requireSenderAdmin(collection)
+    
+    lastLevel = s.tokenUpgradeLevelsByCollection[collection].last
+    
+    require(newLevel.endTime > newLevel.startTime, "End time must be after start time")
+    require(newLevel.startTime > lastLevel.endTime, "Start time must be after last level end time")
+    require(s.tokenUpgradeLevelsByCollection[collection].length + 1 <= s.maxUpgradeLevelCount, "Max upgrade level count reached")
+    
+    s.tokenUpgradeLevelsByCollection[collection].push(newLevel)
+    
+    index = s.tokenUpgradeLevelsByCollection[collection].length - 1
+    
+    s.tokenUpgradeLevelImageURIsByCollection[collection][index] = imageURIs
+    s.blockHashByTokenLevelByCollection[collection][index] = blockhash(block.number)
+    
+    emit :UpgradeLevelUpdated,
+      collection: collection,
+      index: s.tokenUpgradeLevelsByCollection[collection].length - 1,
+      name: newLevel.name,
+      imageURI: newLevel.imageURI,
+      animationURI: newLevel.animationURI,
+      startTime: newLevel.startTime,
+      endTime: newLevel.endTime,
+      newRecord: true
+  end
+  
+  function :editUpgradeLevel, { collection: :address, index: :uint256, newLevel: :TokenUpgradeLevel, imageURIs: [:string] }, :public do
+    requireSenderAdmin(collection)
+    
+    editingFirstLevel = index == 0
+    editingLastLevel = index == s.tokenUpgradeLevelsByCollection[collection].length - 1
+    
+    unless editingLastLevel
+      nextLevel = s.tokenUpgradeLevelsByCollection[collection][index + 1]
+      require(newLevel.endTime < nextLevel.startTime, "End time must be before next level start time")
+    end
+    
+    if editingFirstLevel
+      newLevel.startTime = 0
+      newLevel.endTime = 0
+    else
+      precedingLevel = s.tokenUpgradeLevelsByCollection[collection][index - 1]
+      
+      require(newLevel.startTime > precedingLevel.endTime, "Start time must be after preceding level end time")
+      require(newLevel.endTime > newLevel.startTime, "End time must be after start time")
+    end
+        
+    s.tokenUpgradeLevelsByCollection[collection][index] = newLevel
+    s.tokenUpgradeLevelImageURIsByCollection[collection][index] = imageURIs
+    
+    emit :UpgradeLevelUpdated,
+      collection: collection,
+      index: index,
+      name: newLevel.name,
+      imageURI: newLevel.imageURI,
+      animationURI: newLevel.animationURI,
+      startTime: newLevel.startTime,
+      endTime: newLevel.endTime,
+      newRecord: false
+  end
+  
+  function :activeUpgradeLevelIndex, { collection: :address }, :public, :view, returns: :uint256 do
+    forLoop(
+      condition: -> i { i < s.tokenUpgradeLevelsByCollection[collection].length }
+    ) do |i|
+      level = s.tokenUpgradeLevelsByCollection[collection][i]
+      if level.startTime <= block.timestamp && level.endTime > block.timestamp
+        return i
+      elsif level.startTime > block.timestamp
+        return 0
+      end
+    end
+    
+    return 0
+  end
+  
+  function :activeUpgradeLevel, { collection: :address }, :public, :view, returns: :TokenUpgradeLevel do
+    index = activeUpgradeLevelIndex(collection)
+    
+    return index == 0 ? TokenUpgradeLevel() : s.tokenUpgradeLevelsByCollection[collection][index]
+  end
+  
+  function :_upgradeToken, {
+    collection: :address,
+    tokenId: :uint256,
+    activeUpgrade: :TokenUpgradeLevel
+  }, :internal do
+    require(
+      ERC721(collection).isApprovedOrOwner(spender: msg.sender, id: tokenId),
+      "TokenUpgradeRenderer: msg.sender not authorized to upgrade id #{tokenId.toString}"
+    );
+    
+    tokenStatus = s.tokenStatusByCollection[collection][tokenId]
+
+    require(tokenStatus.lastUpgradeTime < activeUpgrade.startTime, "TokenUpgradeRenderer: Token already upgraded during this period")
+    
+    targetLevelIndex = tokenStatus.upgradeLevel + 1
+    require(targetLevelIndex < s.tokenUpgradeLevelsByCollection[collection].length, "TokenUpgradeRenderer: No more upgrade levels")
+    
+    tokenStatus.upgradeLevel = targetLevelIndex
+    tokenStatus.lastUpgradeTime = block.timestamp
+    
+    emit :TokenUpgraded, collection: collection, tokenId: tokenId, upgradeLevel: tokenStatus.upgradeLevel
+  end
+  
+  function :upgradeMultipleTokens, { collection: :address, tokenIds: [:uint256] }, :public do
+    require(tokenIds.length <= 100, "TokenUpgradeRenderer: Cannot upgrade more than 50 tokens at once")
+    
+    totalFee = s.perUpgradeFee * tokenIds.length
+    if totalFee > 0 && s.feeTo != address(0)
+      ERC20(s.WETH).transferFrom(
+        msg.sender,
+        s.feeTo,
+        totalFee
+      )
+    end
+    
+    activeUpgradeIndex = activeUpgradeLevelIndex(collection)
+    require(activeUpgradeIndex > 0, "TokenUpgradeRenderer: No active upgrade level")
+    
+    activeUpgrade = s.tokenUpgradeLevelsByCollection[collection][activeUpgradeIndex]
+    
+    forLoop(
+      condition: -> i { i < tokenIds.length }
+    ) do |i|
+      _upgradeToken(
+        collection: collection,
+        tokenId: tokenIds[i],
+        activeUpgrade: activeUpgrade
+      )
+    end
+  end
+
+  function :setContractInfo, { collection: :address, info: :ContractInfo }, :public do
+    requireSenderAdmin(collection)
+    
+    s.contractInfoByCollection[collection] = info
+    emit :ContractInfoUpdated, collection: collection, newInfo: info
+  end
+  
+  function :lastUpgradeLevel, { collection: :address, tokenId: :uint256 }, :public, :view, returns: :TokenUpgradeLevel do
+    status = s.tokenStatusByCollection[collection][tokenId]
+    upgradeTime = status.lastUpgradeTime
+    
+    if upgradeTime == 0
+      return TokenUpgradeLevel()
+    end
+    
+    forLoop(
+      condition: -> i { i < s.tokenUpgradeLevelsByCollection[collection].length }
+    ) do |i|
+      level = s.tokenUpgradeLevelsByCollection[collection][i]
+      if level.startTime <= upgradeTime && level.endTime > upgradeTime
+        return level
+      end
+    end
+    
+    return TokenUpgradeLevel()
+  end
+
+  function :tokenURI, { tokenId: :uint256 }, :external, :view, returns: :string do
+    collection = msg.sender
+    
+    status = s.tokenStatusByCollection[collection][tokenId]
+    upgradeLevel = s.tokenUpgradeLevelsByCollection[collection][status.upgradeLevel]
+    
+    name_json = json.stringify("#{upgradeLevel.name} ##{tokenId.toString()}")
+    description_json = json.stringify(s.contractInfoByCollection[collection].description)
+
+    uriAryLength = s.tokenUpgradeLevelImageURIsByCollection[collection][status.upgradeLevel].length
+    
+    imageURI = if uriAryLength > 0
+      blockhash = s.blockHashByTokenLevelByCollection[collection][status.upgradeLevel]
+      entropy = uint256(keccak256(abi.encodePacked(blockhash, tokenId)))
+      
+      s.tokenUpgradeLevelImageURIsByCollection[collection][status.upgradeLevel][entropy % uriAryLength]
+    else
+      upgradeLevel.imageURI
+    end
+    
+    image_field = imageURI.length == 0 ? "" : %Q("image": #{json.stringify(imageURI)},\n)
+    animation_url_field = upgradeLevel.animationURI.length == 0 ? "" : %Q("animation_url": #{json.stringify(upgradeLevel.animationURI)},\n)
+    
+    last_level = lastUpgradeLevel(collection: collection, tokenId: tokenId)
+    last_upgrade_level_json = last_level != TokenUpgradeLevel() ? %Q(, {"trait_type": "Last Upgrade Level", "value": #{json.stringify(last_level.name)}}\n) : ""
+    
+    extra_attributes_json = upgradeLevel.extraAttributesJson != "" ? ", " + upgradeLevel.extraAttributesJson : ""
+    
+    json_data = <<-JSON
+    {
+      "name": #{name_json},
+      "description": #{description_json},
+      #{image_field}
+      #{animation_url_field}
+      "attributes": [
+        {"trait_type": "Number", "display_type": "number", "value": #{tokenId.toString()}},
+        {"trait_type": "Level", "value": #{json.stringify(upgradeLevel.name)}}
+        #{last_upgrade_level_json}
+        #{extra_attributes_json}
+      ]
+    }
+    JSON
+    
+    "data:application/json;base64," + json_data.base64Encode
+  end
+  
+  function :initializeWithData, {
+    contractInfo: :ContractInfo,
+    initialLevel: :TokenUpgradeLevel,
+  }, :external do
+    setContractInfo(
+      collection: msg.sender,
+      info: contractInfo
+    )
+    
+    editUpgradeLevel(
+      collection: msg.sender,
+      index: 0,
+      newLevel: initialLevel
+    )
+    
+    emit :CollectionInitialized, collection: msg.sender, contractInfo: contractInfo, initialLevel: initialLevel
+  end
+  
+  function :contractURI, :external, :view, returns: :string do
+    collection = msg.sender
+    
+    contractInfo = s.contractInfoByCollection[collection]
+    
+    json_data = json.stringify(
+      name: contractInfo.name,
+      description: contractInfo.description,
+      image: contractInfo.imageURI
+    )
+    
+    "data:application/json;base64," + json_data.base64Encode
+  end
+  
+  function :upgradeLevelCount, { collection: :address }, :public, :view, returns: :uint256 do
+    return s.tokenUpgradeLevelsByCollection[collection].length
+  end
+  
+  function :requireSenderAdmin, { target: :address }, :internal, :view do
+    require(target == msg.sender || INFTCollection01(target).owner() == msg.sender, "Admin access only")
+  end
+  
+  function :setFeeTo, { feeTo: :address }, :public do
+    require(msg.sender == s.feeTo, "Only feeTo can change feeTo")
+    
+    s.feeTo = feeTo
+    nil
+  end
+end

--- a/lib/rubidity/contract_implementation.rb
+++ b/lib/rubidity/contract_implementation.rb
@@ -381,6 +381,16 @@ class ContractImplementation < BasicObject
     end
   end
   
+  def uint256(val)
+    if val.is_a?(::TypedVariable) && val.type.is_uint?
+      return downcast_integer(val, 256)
+    elsif val.is_a?(::TypedVariable) && val.type.bytes32?
+      return ::TypedVariable.create(:uint256, val.value)
+    end
+    
+    raise "Not implemented"
+  end
+  
   def sqrt(integer)
     integer = ::TypedVariable.create_or_validate(:uint256, integer)
 

--- a/lib/rubidity/transaction_execution/transaction_context.rb
+++ b/lib/rubidity/transaction_execution/transaction_context.rb
@@ -6,7 +6,7 @@ class TransactionContext < ActiveSupport::CurrentAttributes
   STRUCT_DETAILS = {
     msg:    { attributes: { sender: :address } },
     tx:     { attributes: { origin: :address, current_transaction_hash: :bytes32 } },
-    block:  { attributes: { number: :uint256, timestamp: :uint256, blockhash: :string, chainid: :uint256 } },
+    block:  { attributes: { number: :uint256, timestamp: :uint256, blockhash: :bytes32, chainid: :uint256 } },
   }.freeze
 
   STRUCT_DETAILS.each do |struct_name, details|

--- a/spec/models/nft_upgrade_spec.rb
+++ b/spec/models/nft_upgrade_spec.rb
@@ -555,5 +555,20 @@ RSpec.describe "TokenUpgradeRenderer01", type: :model do
     
     expect(token_uri["attributes"].any? { |attr| attr["trait_type"] == "Last Upgrade Level" }).to be true
     expect(expected_images).to include(token_uri['image'])
+    
+    trigger_contract_interaction_and_expect_error(
+      from: owner_address,
+      payload: {
+        to: upgrader.address,
+        data: {
+          function: "addUpgradeLevel",
+          args: {
+            collection: nft_contract.address,
+            newLevel: new_level,
+            imageURIs: expected_images * 10
+          }
+        }
+      }
+    )
   end
 end


### PR DESCRIPTION
Ability to have multiple image URIs on an upgrade level and choose randomly between them.

Ideally we wouldn't need a separate mapping for the array but right now structs don't support arrays OR adding fields on upgrade.

Here's the contract diff:

```diff
diff --git a/app/models/contracts/TokenUpgradeRenderer01.rubidity b/app/models/contracts/TokenUpgradeRenderer01.rubidity
index d7f83b3..8830d8c 100644
--- a/app/models/contracts/TokenUpgradeRenderer01.rubidity
+++ b/app/models/contracts/TokenUpgradeRenderer01.rubidity
@@ -8,7 +8,7 @@ contract :INFTCollection01, abstract: true do
   function :owner, :external, :view, returns: :address
 end
 
-contract :TokenUpgradeRenderer01, is: :Upgradeable, upgradeable: true do
+contract :TokenUpgradeRenderer02, is: :Upgradeable, upgradeable: true do
   event :CollectionInitialized, {
     collection: :address,
     contractInfo: :ContractInfo,
@@ -61,6 +61,9 @@ contract :TokenUpgradeRenderer01, is: :Upgradeable, upgradeable: true do
   mapping ({ address: mapping(uint256: :TokenStatus) }), :public, :tokenStatusByCollection
   mapping ({ address: :ContractInfo }), :public, :contractInfoByCollection
   
+  mapping ({ address: mapping(uint256: array(:string)) }), :public, :tokenUpgradeLevelImageURIsByCollection
+  mapping ({ address: mapping(uint256: :bytes32) }), :public, :blockHashByTokenLevelByCollection
+  
   uint256 :public, :perUpgradeFee
   address :public, :feeTo
   address :public, :WETH
@@ -79,7 +82,7 @@ contract :TokenUpgradeRenderer01, is: :Upgradeable, upgradeable: true do
     s.WETH = weth
   }
   
-  function :addUpgradeLevel, { collection: :address, newLevel: :TokenUpgradeLevel }, :public do
+  function :addUpgradeLevel, { collection: :address, newLevel: :TokenUpgradeLevel, imageURIs: [:string] }, :public do
     requireSenderAdmin(collection)
     
     lastLevel = s.tokenUpgradeLevelsByCollection[collection].last
@@ -90,6 +93,11 @@ contract :TokenUpgradeRenderer01, is: :Upgradeable, upgradeable: true do
     
     s.tokenUpgradeLevelsByCollection[collection].push(newLevel)
     
+    index = s.tokenUpgradeLevelsByCollection[collection].length - 1
+    
+    s.tokenUpgradeLevelImageURIsByCollection[collection][index] = imageURIs
+    s.blockHashByTokenLevelByCollection[collection][index] = blockhash(block.number)
+    
     emit :UpgradeLevelUpdated,
       collection: collection,
       index: s.tokenUpgradeLevelsByCollection[collection].length - 1,
@@ -101,7 +109,7 @@ contract :TokenUpgradeRenderer01, is: :Upgradeable, upgradeable: true do
       newRecord: true
   end
   
-  function :editUpgradeLevel, { collection: :address, index: :uint256, newLevel: :TokenUpgradeLevel }, :public do
+  function :editUpgradeLevel, { collection: :address, index: :uint256, newLevel: :TokenUpgradeLevel, imageURIs: [:string] }, :public do
     requireSenderAdmin(collection)
     
     editingFirstLevel = index == 0
@@ -123,6 +131,7 @@ contract :TokenUpgradeRenderer01, is: :Upgradeable, upgradeable: true do
     end
         
     s.tokenUpgradeLevelsByCollection[collection][index] = newLevel
+    s.tokenUpgradeLevelImageURIsByCollection[collection][index] = imageURIs
     
     emit :UpgradeLevelUpdated,
       collection: collection,
@@ -242,8 +251,19 @@ contract :TokenUpgradeRenderer01, is: :Upgradeable, upgradeable: true do
     
     name_json = json.stringify("#{upgradeLevel.name} ##{tokenId.toString()}")
     description_json = json.stringify(s.contractInfoByCollection[collection].description)
+
+    uriAryLength = s.tokenUpgradeLevelImageURIsByCollection[collection][status.upgradeLevel].length
+    
+    imageURI = if uriAryLength > 0
+      blockhash = s.blockHashByTokenLevelByCollection[collection][status.upgradeLevel]
+      entropy = uint256(keccak256(abi.encodePacked(blockhash, tokenId)))
+      
+      s.tokenUpgradeLevelImageURIsByCollection[collection][status.upgradeLevel][entropy % uriAryLength]
+    else
+      upgradeLevel.imageURI
+    end
     
-    image_field = upgradeLevel.imageURI.length == 0 ? "" : %Q("image": #{json.stringify(upgradeLevel.imageURI)},\n)
+    image_field = imageURI.length == 0 ? "" : %Q("image": #{json.stringify(imageURI)},\n)
     animation_url_field = upgradeLevel.animationURI.length == 0 ? "" : %Q("animation_url": #{json.stringify(upgradeLevel.animationURI)},\n)
     
     last_level = lastUpgradeLevel(collection: collection, tokenId: tokenId)
```